### PR TITLE
feat(template): Add templates for different chaos experiments

### DIFF
--- a/templates/container-kill-template.yml
+++ b/templates/container-kill-template.yml
@@ -1,0 +1,16 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment 
+  TARGET_CONTAINER: "nginx"
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.container_kill_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running container-kill experiment for the given application
+    - go test tests/container-kill_test.go -v -count=1

--- a/templates/disk-fill-template.yml
+++ b/templates/disk-fill-template.yml
@@ -4,13 +4,11 @@ variables:
   APP_KIND: deployment 
   APP_LABEL: %APPLICATION_LABEL%
   TARGET_CONTAINER: %TARGET_CONTAINER_NAME%
-  TOTAL_CHAOS_DURATION: "30"
-  CHAOS_INTERVAL: "10"
-  FORCE: "false"
+  FILL_PERCENTAGE: 80
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
 
-.pod_delete_template:
+.disk_fill_template:
   image: mayadata-io/chaos-ci-lib:latest
   script:
-    # Running pod delete experiment for the given application
-    - go test tests/pod-delete_test.go -v -count=1
+    # Running disk-fill experiment for the given application
+    - go test tests/disk-fill_test.go -v -count=1

--- a/templates/install-litmus-template.yml
+++ b/templates/install-litmus-template.yml
@@ -1,13 +1,10 @@
 ---
 variables:
   APP_NS: default
-  APP_KIND: deployment 
-  APP_LABEL: %APPLICATION_LABEL%
-  TARGET_CONTAINER: %TARGET_CONTAINER_NAME%
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
 
 .container_kill_template:
   image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running container-kill experiment for the given application
-    - go test tests/container-kill_test.go -v -count=1
+    - go test tests/install-litmus_test.go -v -count=1

--- a/templates/node-cpu-hog-template.yml
+++ b/templates/node-cpu-hog-template.yml
@@ -1,17 +1,15 @@
 ---
 variables:
   APP_NS: default
-  APP_LABEL: "run=nginx"
-  ##only deployment is supported
   APP_KIND: deployment 
+  APP_LABEL: %APPLICATION_LABEL%
+  TARGET_CONTAINER: %TARGET_CONTAINER_NAME%
   TOTAL_CHAOS_DURATION: "60"
   NODE_CPU_CORE: "2"
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
-  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
-  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
 
 .node_cpu_hog_template:
-  image: uditgaurav/gitlab-template:latest
+  image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running node-cpu-hog experiment for the given application
     - go test tests/node-cpu-hog_test.go -v -count=1

--- a/templates/node-cpu-hog-template.yml
+++ b/templates/node-cpu-hog-template.yml
@@ -1,0 +1,17 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment 
+  TOTAL_CHAOS_DURATION: "60"
+  NODE_CPU_CORE: "2"
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.node_cpu_hog_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running node-cpu-hog experiment for the given application
+    - go test tests/node-cpu-hog_test.go -v -count=1

--- a/templates/node-memory-hog-template.yml
+++ b/templates/node-memory-hog-template.yml
@@ -1,0 +1,17 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment 
+  TOTAL_CHAOS_DURATION: "60"
+  MEMORY_PERCENTAGE: "90"
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.node_memory_hog_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running node-memory-hog experiment for the given application
+    - go test tests/node-memory-hog_test.go -v -count=1

--- a/templates/node-memory-hog-template.yml
+++ b/templates/node-memory-hog-template.yml
@@ -1,17 +1,14 @@
 ---
 variables:
   APP_NS: default
-  APP_LABEL: "run=nginx"
-  ##only deployment is supported
   APP_KIND: deployment 
+  APP_LABEL: %APPLICATION_LABEL%
   TOTAL_CHAOS_DURATION: "60"
   MEMORY_PERCENTAGE: "90"
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
-  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
-  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
 
 .node_memory_hog_template:
-  image: uditgaurav/gitlab-template:latest
+  image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running node-memory-hog experiment for the given application
     - go test tests/node-memory-hog_test.go -v -count=1

--- a/templates/pod-cpu-hog-template.yml
+++ b/templates/pod-cpu-hog-template.yml
@@ -1,0 +1,18 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment 
+  TOTAL_CHAOS_DURATION: "60"
+  TARGET_CONTAINER: "nginx"
+  CPU_CORES: "1"
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.pod_cpu_hog_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running pod-cpu-hog experiment for the given application
+    - go test tests/pod-cpu-hog_test.go -v -count=1

--- a/templates/pod-cpu-hog-template.yml
+++ b/templates/pod-cpu-hog-template.yml
@@ -1,18 +1,15 @@
 ---
 variables:
   APP_NS: default
-  APP_LABEL: "run=nginx"
-  ##only deployment is supported
   APP_KIND: deployment 
+  APP_LABEL: %APPLICATION_LABEL%
+  TARGET_CONTAINER: %TARGET_CONTAINER_NAME%
   TOTAL_CHAOS_DURATION: "60"
-  TARGET_CONTAINER: "nginx"
   CPU_CORES: "1"
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
-  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
-  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
 
 .pod_cpu_hog_template:
-  image: uditgaurav/gitlab-template:latest
+  image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running pod-cpu-hog experiment for the given application
     - go test tests/pod-cpu-hog_test.go -v -count=1

--- a/templates/pod-delete-template.yml
+++ b/templates/pod-delete-template.yml
@@ -1,0 +1,18 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment
+  TOTAL_CHAOS_DURATION: "30"
+  CHAOS_INTERVAL: "10"
+  FORCE: "false"
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.pod_delete_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running pod delete experiment for the given application
+    - go test tests/pod-delete_test.go -v -count=1

--- a/templates/pod-memory-hog-template.yml
+++ b/templates/pod-memory-hog-template.yml
@@ -1,18 +1,15 @@
 ---
 variables:
   APP_NS: default
-  APP_LABEL: "run=nginx"
-  ##only deployment is supported
   APP_KIND: deployment 
+  APP_LABEL: %APPLICATION_LABEL%
+  TARGET_CONTAINER: %TARGET_CONTAINER_NAME%
   TOTAL_CHAOS_DURATION: "60"
-  TARGET_CONTAINER: "nginx"
   MEMORY_CONSUMPTION: "500" #In megabytes
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
-  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
-  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
 
 .pod_memory_hog_template:
-  image: uditgaurav/gitlab-template:latest
+  image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running pod-memory-hog experiment for the given application
     - go test tests/pod-memory-hog_test.go -v -count=1

--- a/templates/pod-memory-hog-template.yml
+++ b/templates/pod-memory-hog-template.yml
@@ -1,0 +1,18 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment 
+  TOTAL_CHAOS_DURATION: "60"
+  TARGET_CONTAINER: "nginx"
+  MEMORY_CONSUMPTION: "500" #In megabytes
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.pod_memory_hog_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running pod-memory-hog experiment for the given application
+    - go test tests/pod-memory-hog_test.go -v -count=1

--- a/templates/pod-network-corruption-template.yml
+++ b/templates/pod-network-corruption-template.yml
@@ -1,0 +1,18 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment 
+  TOTAL_CHAOS_DURATION: "60"
+  TARGET_CONTAINER: "nginx"
+  NETWORK_INTERFACE: "eth0"
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.pod_network_corruption_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running pod-network-corruption experiment for the given application
+    - go test tests/pod-network-corruption_test.go -v -count=1

--- a/templates/pod-network-corruption-template.yml
+++ b/templates/pod-network-corruption-template.yml
@@ -1,18 +1,15 @@
 ---
 variables:
   APP_NS: default
-  APP_LABEL: "run=nginx"
-  ##only deployment is supported
   APP_KIND: deployment 
+  APP_LABEL: %APPLICATION_LABEL%
+  TARGET_CONTAINER: %TARGET_CONTAINER_NAME%
   TOTAL_CHAOS_DURATION: "60"
-  TARGET_CONTAINER: "nginx"
   NETWORK_INTERFACE: "eth0"
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
-  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
-  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
 
 .pod_network_corruption_template:
-  image: uditgaurav/gitlab-template:latest
+  image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running pod-network-corruption experiment for the given application
     - go test tests/pod-network-corruption_test.go -v -count=1

--- a/templates/pod-network-latency-template.yml
+++ b/templates/pod-network-latency-template.yml
@@ -1,0 +1,19 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment 
+  TOTAL_CHAOS_DURATION: "60"
+  TARGET_CONTAINER: "nginx"
+  NETWORK_INTERFACE: "eth0"
+  NETWORK_LATENCY: "60000"
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.pod_network_latency_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running pod-network-latency experiment for the given application
+    - go test tests/pod-network-latency_test.go -v -count=1

--- a/templates/pod-network-latency-template.yml
+++ b/templates/pod-network-latency-template.yml
@@ -1,19 +1,16 @@
 ---
 variables:
   APP_NS: default
-  APP_LABEL: "run=nginx"
-  ##only deployment is supported
   APP_KIND: deployment 
+  APP_LABEL: %APPLICATION_LABEL%
+  TARGET_CONTAINER: %TARGET_CONTAINER_NAME% 
   TOTAL_CHAOS_DURATION: "60"
-  TARGET_CONTAINER: "nginx"
   NETWORK_INTERFACE: "eth0"
   NETWORK_LATENCY: "60000"
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
-  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
-  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
 
 .pod_network_latency_template:
-  image: uditgaurav/gitlab-template:latest
+  image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running pod-network-latency experiment for the given application
     - go test tests/pod-network-latency_test.go -v -count=1

--- a/templates/pod-network-loss-template.yml
+++ b/templates/pod-network-loss-template.yml
@@ -1,19 +1,16 @@
 ---
 variables:
   APP_NS: default
-  APP_LABEL: "run=nginx"
-  ##only deployment is supported
   APP_KIND: deployment 
+  APP_LABEL: %APPLICATION_LABEL%
+  TARGET_CONTAINER: %TARGET_CONTAINER_NAME%
   TOTAL_CHAOS_DURATION: "60"
-  TARGET_CONTAINER: "nginx"
   NETWORK_INTERFACE: "eth0"
   NETWORK_PACKET_LOSS_PERCENTAGE: "100"
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
-  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
-  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
 
 .pod_network_loss_template:
-  image: uditgaurav/gitlab-template:latest
+  image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running pod-network-loss experiment for the given application
     - go test tests/pod-network-loss_test.go -v -count=1

--- a/templates/pod-network-loss-template.yml
+++ b/templates/pod-network-loss-template.yml
@@ -1,0 +1,19 @@
+---
+variables:
+  APP_NS: default
+  APP_LABEL: "run=nginx"
+  ##only deployment is supported
+  APP_KIND: deployment 
+  TOTAL_CHAOS_DURATION: "60"
+  TARGET_CONTAINER: "nginx"
+  NETWORK_INTERFACE: "eth0"
+  NETWORK_PACKET_LOSS_PERCENTAGE: "100"
+  EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
+  OPERATOR_IMAGE: litmuschaos/chaos-operator:latest
+  RUNNER_IMAGE: litmuschaos/chaos-runner:latest
+
+.pod_network_loss_template:
+  image: uditgaurav/gitlab-template:latest
+  script:
+    # Running pod-network-loss experiment for the given application
+    - go test tests/pod-network-loss_test.go -v -count=1

--- a/templates/uninstall-litmus-template.yml
+++ b/templates/uninstall-litmus-template.yml
@@ -1,13 +1,10 @@
 ---
 variables:
   APP_NS: default
-  APP_KIND: deployment 
-  APP_LABEL: %APPLICATION_LABEL%
-  TARGET_CONTAINER: %TARGET_CONTAINER_NAME%
   EXPERIMENT_IMAGE: litmuschaos/ansible-runner:latest
 
 .container_kill_template:
   image: mayadata-io/chaos-ci-lib:latest
   script:
     # Running container-kill experiment for the given application
-    - go test tests/container-kill_test.go -v -count=1
+    - go test tests/uninstall-litmus_test.go -v -count=1


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

- Add templates for different chaos experiments. These templates are useful in several ways:
  - Anyone can remotely use these templates to run chaos experiment
  - It will be helpful to test the changes in a simpler way
  - Can be integrated with one's CI

 How to use it?
The templates can be placed in the extends of `gitlab-ci.yml` 